### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once you have at least the requirements installed, you can install Terminus via 
 
 The fastest and easiest way to install Terminus is via Composer. Simply run this in your terminal client:
 ```
-composer require pantheon-systems/terminus
+composer global require pantheon-systems/terminus
 ```
 
 ####Installing with cURL


### PR DESCRIPTION
Add `global` to composer install instructions

Assuming a user will often have multiple 
pantheon projects she may want to run
terminus from, I think global makes 
sense as the default installation.
